### PR TITLE
Update to support .secrets.toml file for sensitive data such as API k…

### DIFF
--- a/.secrets.example.toml
+++ b/.secrets.example.toml
@@ -1,0 +1,3 @@
+# this file contains the secrets for the plugin
+# do not commit this file to the repository as it contains secrets
+authorization = "bearer 123"

--- a/README.md
+++ b/README.md
@@ -63,6 +63,18 @@ When the strategy is "webhook", payloads can be POSTed to the `/webhook` endpoin
 - `live_render` - Set to `false` to disable automatic rendering when Liquid templates change (default `true`)
 - `[polling_headers]` - A section of headers to append to the HTTP poll request (polling strategy only)
 
+## Optional `.secrets.toml`
+
+You can create a `.secrets.toml` file in your plugin directory to store sensitive information like API keys. This file should never be committed to version control.
+
+Example `.secrets.toml`:
+```toml
+X-API-Key = "your-secret-key"
+Authorization = "Bearer your-token"
+```
+
+These headers will be merged with any headers defined in `config.toml`, with `.secrets.toml` taking precedence. To use the secrets in your config, use the `{token}` syntax e.g. `{Authorization}`.
+
 ## Contributing
 
 Bug reports and pull requests are welcome on GitHub at https://github.com/schrockwell/trmnl_preview.

--- a/config.example.toml
+++ b/config.example.toml
@@ -1,3 +1,9 @@
+# Secrets can be stored in .secrets.toml and referenced using {token} syntax 
+# as per the authorization header token below
+# optionally create a .secrets.toml file (see .secrets.example.toml) and add your secrets there
+# The .secrets.toml file should not be committed to version control
+
+
 # strategy = "polling" ==> the data will be fetched once, at server start-up
 # strategy = "webhook" ==> POST new data to /webhook
 strategy = "polling"
@@ -10,5 +16,5 @@ live_render = true
 
 # Polling headers (optional, for polling strategy)
 [polling_headers]
-authorization = "bearer 123"
+authorization = "{authorization}"
 content-type = "application/json"


### PR DESCRIPTION
Update to support **.secrets.toml** file for sensitive data such as API keys. Backwards compatible.

This will automatically replace tokens of the same name in the config.toml

example **.secrets.toml**
```toml
authorization = "bearer 123"
```

example **config.toml**
```toml
authorization = {authorization}
```

